### PR TITLE
Dedup the scripts to run `soracom-inventory-agent-example-start` from the archive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ def createScript(project, mainClass, name) {
     project.tasks[name].dependsOn(project.jar)
     project.applicationDistribution.with {
         into("bin") {
+            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
             from(project.tasks[name])
             fileMode = 0755
         }


### PR DESCRIPTION
Ref: https://docs.gradle.org/current/javadoc/org/gradle/api/file/DuplicatesStrategy.html#EXCLUDE

This can suppress the warnings on unarchived like the following:

```
$ unzip soracom-inventory-agent-example-0.0.8-SNAPSHOT.zip
...
   creating: soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/
  inflating: soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start.bat
  inflating: soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start
replace soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start.bat? [y]es, [n]o, [A]ll, [N]one, [r]ename: Y
  inflating: soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start.bat
replace soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start? [y]es, [n]o, [A]ll, [N]one, [r]ename: Y
```

FYI
--

The archive structure of before this patch:

```
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start.bat
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start.bat
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start
```

Now:

```
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start.bat
soracom-inventory-agent-example-0.0.8-SNAPSHOT/bin/soracom-inventory-agent-example-start
```