### PR TITLE
Update Krypton client to fix key length issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ project(':soracom-inventory-agent-for-java-core') {
         compile "org.eclipse.leshan:leshan-client-cf:${leshanVersion}"
         compile 'org.slf4j:slf4j-api:1.7.30'
         compile 'org.slf4j:slf4j-simple:1.7.30'
-        compile 'io.soracom:soracom-krypton-client-for-java:0.1.0'
+        compile 'io.soracom:soracom-krypton-client-for-java:0.3.0'
     }
 }
 


### PR DESCRIPTION
Krypton client 0.1.0 had an issue that key length was incorrect to get Krypton token.
https://github.com/soracom/soracom-krypton-client-for-java/pull/3

This PR fix the issue by updating Krypton client from 0.1.0 to 0.3.0.