### PR TITLE
Fix bootstrap by SIM authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
     apply plugin: 'maven-publish'
 
     group = 'io.soracom'
-    version = '0.1.0'
+    version = '0.1.1-SNAPSHOT'
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
+++ b/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
@@ -30,6 +30,7 @@ import org.eclipse.leshan.client.californium.LeshanClient;
 import org.eclipse.leshan.client.object.Security;
 import org.eclipse.leshan.client.object.Server;
 import org.eclipse.leshan.core.model.LwM2mModel;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +64,11 @@ public class InventoryAgentHelper {
 
 	public static Server getServerInfo(Credentials c) {
 		if (c == null) {
-			return null;
+			// set default server infor for Inventory's SIM based bootstrap
+			// https://github.com/eclipse/leshan/blob/master/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/LeshanClientBuilder.java#L273
+			// TODO: even the default lifetime sec is set, it will be overwritten by the
+			// server's response value.
+			return new Server(12345, 5 * 60, BindingMode.U, false);
 		} else {
 			return new Server(c.getShortServerId(), c.getLifetime(), c.getBindingMode(), c.isNotifyWhenDisable());
 		}

--- a/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
+++ b/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
@@ -78,7 +78,7 @@ public class InventoryAgentHelper {
 		return Math.max(lifetimeSec, calculateDefaultLifetimeSec());
 	}
 
-	public static long calculateDefaultLifetimeSec() {
+	private static long calculateDefaultLifetimeSec() {
 		// according to
 		// org.eclipse.leshan.client.californium.CaliforniumEndpointsManager.java#getMaxCommunicationPeriodFor
 		return 247 + 30;

--- a/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
+++ b/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
@@ -79,10 +79,9 @@ public class InventoryAgentHelper {
 	}
 
 	public static long calculateDefaultLifetimeSec() {
-		final long defaultLifetimeSec = 60;
 		// according to
 		// org.eclipse.leshan.client.californium.CaliforniumEndpointsManager.java#getMaxCommunicationPeriodFor
-		return defaultLifetimeSec + 247 + 30;
+		return 247 + 30;
 	}
 
 	public static String generateEndpoint() {

--- a/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
+++ b/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelper.java
@@ -74,6 +74,17 @@ public class InventoryAgentHelper {
 		}
 	}
 
+	public static long calculateRecommendedLifetimeSec(long lifetimeSec) {
+		return Math.max(lifetimeSec, calculateDefaultLifetimeSec());
+	}
+
+	public static long calculateDefaultLifetimeSec() {
+		final long defaultLifetimeSec = 60;
+		// according to
+		// org.eclipse.leshan.client.californium.CaliforniumEndpointsManager.java#getMaxCommunicationPeriodFor
+		return defaultLifetimeSec + 247 + 30;
+	}
+
 	public static String generateEndpoint() {
 		try {
 			InetAddress localHost = InetAddress.getLocalHost();

--- a/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentInitializer.java
+++ b/soracom-inventory-agent-for-java-core/src/main/java/io/soracom/inventory/agent/core/initialize/InventoryAgentInitializer.java
@@ -285,15 +285,15 @@ public class InventoryAgentInitializer {
 				log.info("load credentials from credential store.");
 			}
 		}
-		credentials.setLifetime(calculateLifetimeSec());
+		setRecommendedLifetime(credentials);
 		return credentials;
 	}
 
-	private long calculateLifetimeSec() {
-		int defaultLifetimeSec = 60;
-		// according to
-		// org.eclipse.leshan.client.californium.CaliforniumEndpointsManager.java#getMaxCommunicationPeriodFor
-		return defaultLifetimeSec + 247 + 30;
+	private void setRecommendedLifetime(Credentials credentials) {
+		if (credentials != null) {
+			long recommendedLifetime = InventoryAgentHelper.calculateRecommendedLifetimeSec(credentials.getLifetime());
+			credentials.setLifetime(recommendedLifetime);
+		}
 	}
 
 	private Security securityObject;
@@ -322,10 +322,8 @@ public class InventoryAgentInitializer {
 		if (objectInstanceMap.containsKey(LwM2mId.SERVER)) {
 			return;
 		}
-		if (credentials != null) {
-			serverObject = InventoryAgentHelper.getServerInfo(credentials);
-			initializer.setInstancesForObject(LwM2mId.SERVER, serverObject);
-		}
+		serverObject = InventoryAgentHelper.getServerInfo(credentials);
+		initializer.setInstancesForObject(LwM2mId.SERVER, serverObject);
 	}
 
 	private void initObjects(ObjectsInitializer initializer) {

--- a/soracom-inventory-agent-for-java-core/src/test/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelperTest.java
+++ b/soracom-inventory-agent-for-java-core/src/test/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelperTest.java
@@ -1,0 +1,21 @@
+package io.soracom.inventory.agent.core.initialize;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class InventoryAgentHelperTest {
+
+	@Test
+	public void testCalculateDefaultLifetimeSec() {
+		assertEquals(60 + 247 + 30, InventoryAgentHelper.calculateDefaultLifetimeSec());
+	}
+
+	@Test
+	public void calculateRecommendedLifetimeSec() {
+		assertEquals(60 + 247 + 30, InventoryAgentHelper.calculateRecommendedLifetimeSec(0));
+		assertEquals(60 + 247 + 30, InventoryAgentHelper.calculateRecommendedLifetimeSec(60));
+		assertEquals(60 + 247 + 30 + 1, InventoryAgentHelper.calculateRecommendedLifetimeSec(60 + 247 + 30 + 1));
+	}
+
+}

--- a/soracom-inventory-agent-for-java-core/src/test/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelperTest.java
+++ b/soracom-inventory-agent-for-java-core/src/test/java/io/soracom/inventory/agent/core/initialize/InventoryAgentHelperTest.java
@@ -8,14 +8,14 @@ public class InventoryAgentHelperTest {
 
 	@Test
 	public void testCalculateDefaultLifetimeSec() {
-		assertEquals(60 + 247 + 30, InventoryAgentHelper.calculateDefaultLifetimeSec());
+		assertEquals(247 + 30, InventoryAgentHelper.calculateDefaultLifetimeSec());
 	}
 
 	@Test
 	public void calculateRecommendedLifetimeSec() {
-		assertEquals(60 + 247 + 30, InventoryAgentHelper.calculateRecommendedLifetimeSec(0));
-		assertEquals(60 + 247 + 30, InventoryAgentHelper.calculateRecommendedLifetimeSec(60));
-		assertEquals(60 + 247 + 30 + 1, InventoryAgentHelper.calculateRecommendedLifetimeSec(60 + 247 + 30 + 1));
+		assertEquals(247 + 30, InventoryAgentHelper.calculateRecommendedLifetimeSec(0));
+		assertEquals(247 + 30, InventoryAgentHelper.calculateRecommendedLifetimeSec(60));
+		assertEquals(247 + 30 + 1, InventoryAgentHelper.calculateRecommendedLifetimeSec(247 + 30 + 1));
 	}
 
 }


### PR DESCRIPTION
This PR fixes bootstrap issue by SIM authentication.

- Since Leshan 1.2, Server object is necessary for bootstrapping with SIM authentication, so fixed to return the Server object even if there is no credential.
- Fixed the problem of NPE when loading credentials.
- Set recommended lifetime value to server object when bootstrap is succeeded